### PR TITLE
Added fix for method not being accounted for in TrieRouteMatcher

### DIFF
--- a/Source/TrieRouteMatcher.swift
+++ b/Source/TrieRouteMatcher.swift
@@ -35,36 +35,42 @@ public struct TrieRouteMatcher: RouteMatcherType {
         var nextComponentId = 1
 
         for route in routes {
-
-            // turn component (string) into an id (integer) for fast comparisons
-            let componentIds = route.path.split("/").map { component -> Int in
-
-                // if it already has a component with the same name, use that id
-                if let id = componentsTrie.findPayload(component.characters) {
+            
+            for method in route.methods {
+                
+                // add the method to the path so it is checked
+                let path = method.description + route.path
+                
+                // turn component (string) into an id (integer) for fast comparisons
+                let componentIds = path.split("/").map { component -> Int in
+                    
+                    // if it already has a component with the same name, use that id
+                    if let id = componentsTrie.findPayload(component.characters) {
+                        return id
+                    }
+                    
+                    let id: Int
+                    
+                    if component.characters.first == ":" {
+                        // if component is a parameter, give it a negative id
+                        id = -nextComponentId
+                    } else {
+                        // normal component, give it a positive id
+                        id = nextComponentId
+                    }
+                    
+                    // increment id for next component
+                    nextComponentId += 1
+                    
+                    // insert the component into the trie with the next id
+                    componentsTrie.insert(component.characters, payload: id)
+                    
                     return id
                 }
 
-                let id: Int
-
-                if component.characters.first == ":" {
-                    // if component is a parameter, give it a negative id
-                    id = -nextComponentId
-                } else {
-                    // normal component, give it a positive id
-                    id = nextComponentId
-                }
-
-                // increment id for next component
-                nextComponentId += 1
-
-                // insert the component into the trie with the next id
-                componentsTrie.insert(component.characters, payload: id)
-
-                return id
+                // insert the components with the end node containing the route
+                routesTrie.insert(componentIds, payload: route)
             }
-
-            // insert the components with the end node containing the route
-            routesTrie.insert(componentIds, payload: route)
         }
     }
 
@@ -79,8 +85,7 @@ public struct TrieRouteMatcher: RouteMatcherType {
             return nil
         }
 
-        let components = path.split("/")
-
+        let components = [request.method.description] + path.split("/")
         // topmost route node. children are searched for route matches,
         // if they match, that matching node gets set to head
         var head = routesTrie
@@ -92,7 +97,6 @@ public struct TrieRouteMatcher: RouteMatcherType {
 
             // search for component in the components dictionary
             let id = componentsTrie.findPayload(component.characters)
-
 
             // either parameter or 404
             if id == nil {


### PR DESCRIPTION
Was trying out the new HTTPServer and found that it wasn't considering the request method on requests so a GET would match a POST route and vice versa depending on the order specified.

Not sure if this is how you'd want to address it but figured a fix is better than just filing an issue.
